### PR TITLE
Fix panic when iteration continues after error.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -278,7 +278,12 @@ impl Iterator for Parser {
         self.point += 1;
 
         match self.opts.get(&opt) {
-            None => Some(Err(Error::new(ErrorKind::UnknownOption, opt))),
+            None => {
+                if self.point >= self.args[self.index].len() {
+                    self.incr_index();
+                }
+                Some(Err(Error::new(ErrorKind::UnknownOption, opt)))
+            }
             Some(false) => {
                 if self.point >= self.args[self.index].len() {
                     self.incr_index();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -104,3 +104,15 @@ fn multiple() -> Result<(), String> {
 
     Ok(())
 }
+
+#[test]
+fn continue_after_error() {
+    let args: Vec<String> = vec!["x", "-z", "-abc"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let optstring = "ab:d:e".to_string();
+    for _opt in Parser::new(&args, &optstring) {
+        // do nothing, should not panic
+    }
+}


### PR DESCRIPTION
The point field is always incremented after every call to next. However
if the option was invalid, the error was returned to the user without
checking that the parser was in a valid state. This could lead to
a panic on the next call when index would then be out of bounds.

This change also checks that point >= the length on the error path,
incrementing it if necessary.